### PR TITLE
skip not user collections

### DIFF
--- a/packages/openapi/src/options.ts
+++ b/packages/openapi/src/options.ts
@@ -20,6 +20,7 @@ export interface RawOptions {
     passwordRecovery?: boolean;
     preferences?: boolean;
     custom?: boolean;
+    others?: string[]
   };
   /**
    * Payload version is automatically determined.
@@ -41,6 +42,7 @@ export interface Options {
     passwordRecovery: boolean;
     preferences: boolean;
     custom: boolean;
+    others: string[]
   };
   supports: {
     bulkOperations: boolean;
@@ -65,6 +67,7 @@ export const parseOptions = async (options: RawOptions = {}, payloadConfig: Sani
       passwordRecovery: options.exclude?.passwordRecovery === false,
       preferences: options.exclude?.preferences === false,
       custom: !options.exclude?.custom,
+      others: options.exclude?.others || [],
     },
     supports: {
       bulkOperations: supports(toVersion('1.6.24'), payloadVersion),

--- a/packages/openapi/src/payload-config/index.ts
+++ b/packages/openapi/src/payload-config/index.ts
@@ -14,8 +14,12 @@ export const analyzePayload = async (payloadConfig: SanitizedConfig, options: Op
   const { paths: preferencePaths, components: preferenceComponents } = createPreferenceRouts(options);
   const { paths: accessPath, components: accessComponents } = createAccessRoute(options);
 
+  const includedCollections = payloadConfig.collections.filter(
+      collection => !options.include?.others.includes(collection.slug),
+  )
+
   const collectionDefinitions = await Promise.all(
-    payloadConfig.collections.map(collection => getCollectionRoutes(collection, options, payloadConfig)),
+    includedCollections.map(collection => getCollectionRoutes(collection, options, payloadConfig)),
   );
   const globalDefinitions = await Promise.all(
     payloadConfig.globals.map(global => getGlobalRoutes(global, options, payloadConfig)),


### PR DESCRIPTION
Fixes #72 

Add a function to skip collections that are not part of user collections. Use as:

```js
    swagger({
      exclude: {
        others: ['payload-preferences', 'payload-migrations'],
      },
    }),

```

- [ ] Tests 
- [ ] Appropriate changes to README are included in PR
