### PR TITLE
Add missing properties for error response object

### DIFF
--- a/packages/openapi/src/base-config/error.ts
+++ b/packages/openapi/src/base-config/error.ts
@@ -14,6 +14,20 @@ export const error: OpenAPIV3.SchemaObject = {
           message: {
             type: 'string',
           },
+          name: {
+            type: 'string
+          },
+          data: {
+            type: 'array',
+            items: {
+              type: 'object',
+              required: ['field', 'message'],
+              properties: {
+                field: { type: 'string' },
+                message: { type: 'string' }
+              }
+            }
+          }
         },
         required: ['message'],
       },


### PR DESCRIPTION
The error response from Payload does not reflect the error response in the OpenAPI due to missing properties. This means that if anyone wants to use i.e openapi-fetch, they won't be able to use those properties or they will have to override the types.

I have added the missing properties and set them to optional to make sure it's backwards compatible. 

I tested the old schema vs. the new schema with different error objects. 